### PR TITLE
Avoid racing condition of relativeTimestamps

### DIFF
--- a/LFLiveKit/LFLiveSession.m
+++ b/LFLiveKit/LFLiveSession.m
@@ -349,9 +349,6 @@
 #pragma mark -- PrivateMethod
 
 - (void)pushSendBuffer:(LFFrame*)frame{
-    if(self.relativeTimestamps == 0){
-        self.relativeTimestamps = frame.timestamp;
-    }
     frame.timestamp = [self uploadTimestamp:frame.timestamp];
     [self.socket sendFrame:frame];
 }
@@ -818,6 +815,9 @@
 
 - (uint64_t)uploadTimestamp:(uint64_t)captureTimestamp{
     dispatch_semaphore_wait(self.lock, DISPATCH_TIME_FOREVER);
+    if (self.relativeTimestamps == 0) {
+        self.relativeTimestamps = captureTimestamp;
+    }
     uint64_t currentts = 0;
     currentts = captureTimestamp - self.relativeTimestamps;
     dispatch_semaphore_signal(self.lock);


### PR DESCRIPTION
### Description

為了避免直播時，音視頻 frame 的時間異常。因從硬體讀取每一個 frame 的時候會先紀錄絕對時間，然後再用第一個 encoded 後的 frame 時間當作計算相對時間的基準，最後發出去的時間是相對時間。

但音頻及視頻有可能會同時進入，在沒加鎖的情況，計算相對時間的時候有機會造成基準值是較慢 frame 的時間，這樣就會造成前面幾個 frame 的時間都為 0，詳見下面測試一數據。

註：原本加鎖的地方只有在計算相對時間的區塊，現在把基準時間的設置也加入鎖的區塊。

### 測試一（改動前）

| | Video      | Audio |
| :-----------: | :-----------: | :-----------: |
| Abs Time / Relative Time | 9044919 / -35(0)  |  9044954 / 0 |
| Abs Time / Relative Time | 9044919 / -35(0)  |  9044977 / 23 |
| Abs Time / Relative Time | 9044954 / 0  |  9045000 / 46 |
| Abs Time / Relative Time | 9044986 / 32  |  9045023 / 69 |
| Abs Time / Relative Time | 9045020 / 66  |  9045046 / 92 |
| Abs Time / Relative Time | 9045053 / 99  |  9045070 / 116 |
| Abs Time / Relative Time | 9045085 / 131  |  9045093 / 139 |
| Abs Time / Relative Time | 9045121 / 167  |  9045116 / 162 |
| Abs Time / Relative Time | 9045153 / 199  |  9045139 / 185 |
| Abs Time / Relative Time | 9045188 / 234  |  9045163 / 209 |
| Abs Time / Relative Time | 9045220 / 266  |  9045186 / 232 |
| Abs Time / Relative Time | 9045253 / 299  |  9045209 / 255 |
| Abs Time / Relative Time | 9045286 / 332  |  9045232 / 278 |
| Abs Time / Relative Time | 9045320 / 366  |  9045255 / 301 |
| Abs Time / Relative Time | 9045355 / 401  |  9045279 / 325 |
| Abs Time / Relative Time | 9045386 / 432  |  9045302 / 348 |
| Abs Time / Relative Time | 9045422 / 468  |  9045325 / 371 |
| Abs Time / Relative Time | 9045453 / 499  |  9045348 / 394 |
| Abs Time / Relative Time | 9045486 / 532  |  9045372 / 418 |
| Abs Time / Relative Time | 9045520 / 566  |  9045395 / 441 |

### 測試二（改動後）

| | Video      | Audio |
| :-----------: | :-----------: | :-----------: |
| Abs Time / Relative Time | 3619030 / 0  |  3619083 / 53 |
| Abs Time / Relative Time | 3619062 / 32  |  3619106 / 76 |
| Abs Time / Relative Time | 3619096 / 66  |  3619129 / 99 |
| Abs Time / Relative Time | 3619129 / 99  |  3619153 / 123 |
| Abs Time / Relative Time | 3619163 / 133  |  3619176 / 146 |
| Abs Time / Relative Time | 3619195 / 165  |  3619199 / 169 |
| Abs Time / Relative Time | 3619234 / 204  |  3619222 / 192 |
| Abs Time / Relative Time | 3619262 / 232  |  3619245 / 215 |
| Abs Time / Relative Time | 3619297 / 267  |  3619315 / 239 |
| Abs Time / Relative Time | 3619330 / 300  |  3619292 / 262 |
| Abs Time / Relative Time | 3619365 / 335  |  3619315 / 285 |
| Abs Time / Relative Time | 3619397 / 367  |  3619338 / 308 |
| Abs Time / Relative Time | 3619432 / 402  |  3619362 / 332 |
| Abs Time / Relative Time | 3619466 / 436  |  3619385 / 355 |
| Abs Time / Relative Time | 3619498 / 468  |  3619408 / 378 |
| Abs Time / Relative Time | 3619532 / 502  |  3619431 / 401 |
| Abs Time / Relative Time | 3619564 / 534  |  3619455 / 425 |
| Abs Time / Relative Time | 3619605 / 575  |  3619478 / 448 |
| Abs Time / Relative Time | 3619632 / 602  |  3619501 / 471 |
| Abs Time / Relative Time | 3619664 / 634  |  3619524 / 494 |

測試裝置：iPhone 6 Plus