### PR TITLE
iOS 16.4 編碼器問題

### DIFF
--- a/LFLiveKit/LFLiveSession.m
+++ b/LFLiveKit/LFLiveSession.m
@@ -451,7 +451,11 @@
 #if DEBUG
         NSLog(@"change bitrate !!!! %@", @(expected));
 #endif
-        [self.videoEncoder setVideoBitRate:expected];
+        NSUInteger adjustment = 1;
+        if ([[[UIDevice currentDevice] systemVersion] isEqualToString:@"16.4"]) {
+            adjustment = 4.8;
+        }
+        [self.videoEncoder setVideoBitRate:expected * adjustment];
           
         [[LFStreamLog logger] logWithDict:@{
             @"lt": @"pbrt",


### PR DESCRIPTION
#### Why
iOS 16.4 上編碼器有問題，會造成位元率只有需求的 20%~25%。

#### How

先在 iOS 16.4 上將目標位元率乘上約 5 倍。大致達到原本希望的行為。

#### Risk

Medium

