### PR TITLE
Fix bitrate for 15 fps settings

### DIFF
--- a/LFLiveKit/LFLiveSession.m
+++ b/LFLiveKit/LFLiveSession.m
@@ -453,7 +453,7 @@
 #endif
         NSUInteger adjustment = 1;
         if ([[[UIDevice currentDevice] systemVersion] isEqualToString:@"16.4"]) {
-            adjustment = 4.8;
+            adjustment = 4;
         }
         [self.videoEncoder setVideoBitRate:expected * adjustment];
           

--- a/LFLiveKit/configuration/LFLiveVideoConfiguration.m
+++ b/LFLiveKit/configuration/LFLiveVideoConfiguration.m
@@ -92,7 +92,7 @@
             configuration.videoSize = CGSizeMake(720, 1280);
         } break;
         case LFLiveVideoQuality_High2:{
-            configuration.videoFrameRate = 24;
+            configuration.videoFrameRate = 15;
             configuration.videoMaxFrameRate = 24;
             configuration.videoMinFrameRate = 12;
             configuration.videoBitRate = 1200 * 1000;


### PR DESCRIPTION
#### Why

Currently, we use high 2 settings for thermal issue devices. High 2 preset expects 24 FPS, higher than actual 15 FPS. The 50% discrepancy again causes bitrate ratcheting down problem.

#### How

Match high 2 FPS setting to 15.

#### Risk

Medium